### PR TITLE
Fix persist/2 and load/2

### DIFF
--- a/lib/stash.ex
+++ b/lib/stash.ex
@@ -234,6 +234,8 @@ defmodule Stash do
   """
   @spec load(atom, binary) :: atom
   deft load(cache, path) when is_binary(path) do
+    path = :binary.bin_to_list(path)
+
     case :dets.open_file(path, gen_dts_args(cache)) do
       { :ok, ^path } ->
         :dets.to_ets(path, cache)
@@ -253,6 +255,8 @@ defmodule Stash do
   """
   @spec persist(atom, binary) :: atom
   deft persist(cache, path) when is_binary(path) do
+    path = :binary.bin_to_list(path)
+
     case :dets.open_file(path, gen_dts_args(cache)) do
       { :ok, ^path } ->
         :dets.from_ets(path, cache)


### PR DESCRIPTION
This is to fix https://github.com/whitfin/stash/issues/1. Currently `persist/2` and `load/2` seem broken due to wrong data type for `path`.
 
Currently `path` is passed as a String; however, the Erlang functions do not see to accept a String.

```elixir
iex> :dets.open_file(:my_dets_table, file: 'hello')
{:ok, :my_dets_table}

iex> :dets.open_file(:my_dets_table, file: "world")
** (ArgumentError) argument error
    (stdlib 3.15.1) dets.erl:658: :dets.open_file(:my_dets_table, [file: "world"])
```

As soon as the data type is corrected, it gets working as expected.